### PR TITLE
Adds content to the init files for easier import.

### DIFF
--- a/src/tensorflow_wavelets/Layers/__init__.py
+++ b/src/tensorflow_wavelets/Layers/__init__.py
@@ -1,0 +1,4 @@
+from tensorflow_wavelets.Layers.DMWT import DMWT, IDMWT
+from tensorflow_wavelets.Layers.DWT import DWT, IDWT
+from tensorflow_wavelets.Layers.DTCWT import DTCWT, IDTCWT
+from tensorflow_wavelets.Layers.Threshold import Threshold

--- a/src/tensorflow_wavelets/__init__.py
+++ b/src/tensorflow_wavelets/__init__.py
@@ -1,0 +1,2 @@
+import tensorflow_wavelets.Layers as Layers
+import tensorflow_wavelets.utils as utils

--- a/src/tensorflow_wavelets/utils/__init__.py
+++ b/src/tensorflow_wavelets/utils/__init__.py
@@ -1,0 +1,1 @@
+from tensorflow_wavelets.utils import *


### PR DESCRIPTION
Error Description:
When I installed the package for my BA thesis I could not import any of its contents. After some looking around I think the problem are the empty `__init__.py` files.

Fix Description:
I filled in the imports as I saw fit. This way I can import the classes.

I hope that is alright.