### PR TITLE
Typo in IDWT documentation

### DIFF
--- a/src/tensorflow_wavelets/Layers/DWT.py
+++ b/src/tensorflow_wavelets/Layers/DWT.py
@@ -114,7 +114,7 @@ class IDWT(layers.Layer):
     Inputs:
         name - wavelet name ( from pywavelet library)
         splited - 0 - not splitted One channel input([[ll , lh],[hl, hh]])
-                  0 - splitted 4 channels input([ll , lh, hl ,hh])
+                  1 - splitted 4 channels input([ll , lh, hl ,hh])
     """
     def __init__(self, wavelet_name='haar', splited=0, **kwargs):
         super(IDWT, self).__init__(**kwargs)


### PR DESCRIPTION
In the `IDWT` class, constructor `_init_`, parameter `splited` can take value 0 or 1. However, 0 was mentioned twice in the documentation which may cause confusion to others using this resource.