### PR TITLE
Fixing IDWT layer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 scipy==1.5.2
 matplotlib~=3.4.3
 tensorflow~=2.6.0
-keras~=2.6.0
+keras~=2.9.0
 psnr-hvsm==0.1.0
 opencv-python
 scikit-image
 pywavelets
+tensorflow_probability~=0.19.0
+numpy~=1.21.6

--- a/src/tensorflow_wavelets/Layers/DWT.py
+++ b/src/tensorflow_wavelets/Layers/DWT.py
@@ -116,12 +116,12 @@ class IDWT(layers.Layer):
         splited - 0 - not splitted One channel input([[ll , lh],[hl, hh]])
                   1 - splitted 4 channels input([ll , lh, hl ,hh])
     """
-    def __init__(self, wavelet_name='haar', splited=0, **kwargs):
+    def __init__(self, wavelet_name='haar', concat=1, **kwargs):
         super(IDWT, self).__init__(**kwargs)
         # self._name = self.name + "_" + name
         self.pad_type = "VALID"
         self.border_pad = "SYMMETRIC"
-        self.splited = splited
+        self.concat = concat
         # get filter coeffs from 3rd party lib
         wavelet = pywt.Wavelet(wavelet_name)
         self.rec_len = wavelet.rec_len
@@ -139,8 +139,12 @@ class IDWT(layers.Layer):
 
     def call(self, inputs, training=None, mask=None):
 
-        if self.splited == 1:
-            x = inputs
+        if self.concat == 0:
+            ll = tf.expand_dims(inputs[:,:,:,0], axis = -1)
+            lh = tf.expand_dims(inputs[:,:,:,1], axis = -1)
+            hl = tf.expand_dims(inputs[:,:,:,2], axis = -1)
+            hh = tf.expand_dims(inputs[:,:,:,3], axis = -1)
+            x = tf.concat([ll, hl, lh, hh], axis=-1)
         else:
             ll_lh_hl_hh = tf.split(inputs, 2, axis=1)
             ll_lh = tf.split(ll_lh_hl_hh[0], 2, axis=2)

--- a/src/tensorflow_wavelets/Layers/DWT.py
+++ b/src/tensorflow_wavelets/Layers/DWT.py
@@ -113,8 +113,8 @@ class IDWT(layers.Layer):
     Inverse Discrete Wavelet Transform - Tensorflow - keras
     Inputs:
         name - wavelet name ( from pywavelet library)
-        splited - 0 - not splitted One channel input([[ll , lh],[hl, hh]])
-                  1 - splitted 4 channels input([ll , lh, hl ,hh])
+        concat - 1 - not splitted One channel input([[ll , lh],[hl, hh]])
+                  0 - splitted 4 channels input([ll , lh, hl ,hh])
     """
     def __init__(self, wavelet_name='haar', concat=1, **kwargs):
         super(IDWT, self).__init__(**kwargs)

--- a/src/tensorflow_wavelets/Layers/Threshold.py
+++ b/src/tensorflow_wavelets/Layers/Threshold.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     x_inp = layers.Input(shape=(h, w, c))
     x = DWT.DWT(name="db2", concat=1)(x_inp)
     x = Threshold(algo='sure', mode='soft')(x)
-    x = DWT.IDWT(name="db2", splited=0)(x)
+    x = DWT.IDWT(name="db2", concat=1)(x)
     model = Model(x_inp, x, name="mymodel")
     model.run_eagerly = True
     model.summary()

--- a/src/tensorflow_wavelets/utils/models.py
+++ b/src/tensorflow_wavelets/utils/models.py
@@ -8,14 +8,14 @@ import tensorflow_wavelets.Layers.Threshold as Activation
 from tensorflow.keras.models import Model
 
 
-def basic_dwt_idwt(input_shape, wave_name="db2", eagerly=False, theshold=True, mode='soft', algo='sure'):
+def basic_dwt_idwt(input_shape, wave_name="db2", eagerly=False, theshold=True, mode='soft', algo='sure', concat = True):
     # load DWT IDWT model
     model = keras.Sequential()
     model.add(layers.InputLayer(input_shape=input_shape))
-    model.add(DWT.DWT(wavelet_name=wave_name))
+    model.add(DWT.DWT(wavelet_name=wave_name, concat = concat))
     if theshold:
         model.add(Activation.Threshold(algo=algo, mode=mode))
-    model.add(DWT.IDWT(wavelet_name=wave_name))
+    model.add(DWT.IDWT(wavelet_name=wave_name, concat = concat))
 
     # for debug with break points
     model.run_eagerly = eagerly

--- a/src/test.py
+++ b/src/test.py
@@ -1,5 +1,6 @@
 import cv2
 import unittest
+import os
 
 from tensorflow_wavelets.utils.models import *
 from tensorflow_wavelets.utils.mse import *
@@ -20,42 +21,54 @@ class TestSrc(unittest.TestCase):
         if not change the path of lenna_input_path
     '''
     lenna_input_path = "../Development/input/LennaGrey.png"
-
+    
     def test_dwt_idwt_sof_thresh(self):
 
         img = cv2.imread(self.lenna_input_path, 0)
-        self.assertIsNotNone(img, "LennaGrey.png not flound in " + self.lenna_input_path)
+        self.assertIsNotNone(img, "LennaGrey.png not found in " + self.lenna_input_path)
         img_ex1 = np.expand_dims(img, axis=-1)
         img_ex2 = np.expand_dims(img_ex1, axis=0)
         model = basic_dwt_idwt(input_shape=img_ex1.shape, wave_name="db2", eagerly=True, theshold=True, mode='soft', algo='sure')
         rec = model.predict(img_ex2)
         rec = rec[0, ..., 0]
         mse_lim = 3.5
-        self.assertLess(mse(img, rec), mse_lim, "Should be less then" + str(mse_lim))
+        self.assertLess(mse(img, rec), mse_lim, "Should be less than " + str(mse_lim))
 
     def test_dwt_idwt_hard_thresh(self):
 
         img = cv2.imread(self.lenna_input_path, 0)
-        self.assertIsNotNone(img, "LennaGrey.png not flound in " + self.lenna_input_path)
+        self.assertIsNotNone(img, "LennaGrey.png not found in " + self.lenna_input_path)
         img_ex1 = np.expand_dims(img, axis=-1)
         img_ex2 = np.expand_dims(img_ex1, axis=0)
         model = basic_dwt_idwt(input_shape=img_ex1.shape, wave_name="db2", eagerly=True, theshold=True, mode='hard', algo='sure')
         rec = model.predict(img_ex2)
         rec = rec[0, ..., 0]
         mse_lim = 3.5
-        self.assertLess(mse(img, rec), mse_lim, "Should be less then" + str(mse_lim))
+        self.assertLess(mse(img, rec), mse_lim, "Should be less than " + str(mse_lim))
 
     def test_dwt_idwt(self):
 
         img = cv2.imread(self.lenna_input_path, 0)
-        self.assertIsNotNone(img, "LennaGrey.png not flound in " + self.lenna_input_path)
+        self.assertIsNotNone(img, "LennaGrey.png not found in " + self.lenna_input_path)
         img_ex1 = np.expand_dims(img, axis=-1)
         img_ex2 = np.expand_dims(img_ex1, axis=0)
         model = basic_dwt_idwt(input_shape=img_ex1.shape, wave_name="db2", eagerly=True, theshold=False)
         rec = model.predict(img_ex2)
         rec = rec[0, ..., 0]
         mse_lim = 1e-3
-        self.assertLess(mse(img, rec), mse_lim, "Should be less then" + str(mse_lim))
+        self.assertLess(mse(img, rec), mse_lim, "Should be less than " + str(mse_lim))
+
+    def test_dwt_idwt_not_concat(self):
+
+        img = cv2.imread(self.lenna_input_path, 0)
+        self.assertIsNotNone(img, "LennaGrey.png not found in " + self.lenna_input_path)
+        img_ex1 = np.expand_dims(img, axis=-1)
+        img_ex2 = np.expand_dims(img_ex1, axis=0)
+        model = basic_dwt_idwt(input_shape=img_ex1.shape, wave_name="db2", eagerly=True, theshold=False, concat = False)
+        rec = model.predict(img_ex2)
+        rec = rec[0, ..., 0]
+        mse_lim = 1e-3
+        self.assertLess(mse(img, rec), mse_lim, "Should be less than " + str(mse_lim))
 
     def test_basic_train_mnist(self):
         (x_train, y_train), (x_test, y_test) = load_mnist(remove_n_samples=1000)


### PR DESCRIPTION
This PR contains changes to the code for the IDWT layer which did not work as intended. The problem was relative to the concat/splitted parameters from the DWT and IDWT layers respectivelly. In my understand, if using concat = 0 on the DWT layer, you should be using the splitted = 1 parameter on the IDWT layer, and if calling both layers on a matrix you should get the original matrix as a result, however, this was not the case.

The unit tests passed on the previous implementation because the unit test always used concat = 1 and splitted = 0, for which case the layers were working as intended. Because of this I also added a new unit test to account for this second combination of parameters. 

Finally, I changed the splited parameter of the IDWT layer name to concat for more consistency and ease of use of the layers, so now, using concat = 0 on the DWT layer means that you will use concat = 0 in the IDWT layer as well, instead of using different boolean values on each of them.

Some typos were fixed. I also had to change the requirements to include some new libraries, this may be problematic, but I could not run the code without adding it. This is my first contribution to a public library, so I am sorry if I have made any rookie mistakes.       